### PR TITLE
Update image job creation self test

### DIFF
--- a/self-test/app/composer.json
+++ b/self-test/app/composer.json
@@ -3,7 +3,9 @@
     "license": "proprietary",
     "require": {
         "guzzlehttp/guzzle": "^7.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "smartassert/yaml-file": "^4.0",
+        "symfony/yaml": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/self-test/app/src/ApplicationTest.php
+++ b/self-test/app/src/ApplicationTest.php
@@ -12,7 +12,7 @@ class ApplicationTest extends TestCase
     private const JOB_LABEL = 'job-label-content';
     private const JOB_MAXIMUM_DURATION_IN_SECONDS = 600;
 
-    private const CALLBACK_URL = 'http://callback-receiver:8080/';
+    private const EVENT_DELIVERY_URL = 'http://callback-receiver:8080/';
 
     private static Client $httpClient;
     private static string $fixturePath;
@@ -32,7 +32,7 @@ class ApplicationTest extends TestCase
         $createJobResponse = self::$httpClient->post('https://localhost/job', [
             'form_params' => [
                 'label' => self::JOB_LABEL,
-                'callback-url' => self::CALLBACK_URL,
+                'event_delivery_url' => self::EVENT_DELIVERY_URL,
                 'maximum-duration-in-seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
             ],
         ]);
@@ -40,7 +40,7 @@ class ApplicationTest extends TestCase
         self::assertSame('application/json', $createJobResponse->getHeaderLine('content-type'));
         $this->assertJobStatus([
             'label' => self::JOB_LABEL,
-            'callback_url' => self::CALLBACK_URL,
+            'callback_url' => self::EVENT_DELIVERY_URL,
             'maximum_duration_in_seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
             'sources' => [],
             'compilation_states' => ['awaiting'],
@@ -72,7 +72,7 @@ class ApplicationTest extends TestCase
         self::assertSame('application/json', $addSourcesResponse->getHeaderLine('content-type'));
         $this->assertJobStatus([
             'label' => self::JOB_LABEL,
-            'callback_url' => self::CALLBACK_URL,
+            'callback_url' => self::EVENT_DELIVERY_URL,
             'maximum_duration_in_seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
             'sources' => [
                 'test.yml',

--- a/self-test/app/src/ApplicationTest.php
+++ b/self-test/app/src/ApplicationTest.php
@@ -33,7 +33,7 @@ class ApplicationTest extends TestCase
             'form_params' => [
                 'label' => self::JOB_LABEL,
                 'event_delivery_url' => self::EVENT_DELIVERY_URL,
-                'maximum-duration-in-seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
+                'maximum_duration_in_seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
             ],
         ]);
         self::assertSame(200, $createJobResponse->getStatusCode());

--- a/self-test/app/src/ApplicationTest.php
+++ b/self-test/app/src/ApplicationTest.php
@@ -6,6 +6,12 @@ namespace App;
 
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
+use SmartAssert\YamlFile\Collection\ArrayCollection;
+use SmartAssert\YamlFile\Collection\Serializer as YamlFileCollectionSerializer;
+use SmartAssert\YamlFile\FileHashes;
+use SmartAssert\YamlFile\FileHashes\Serializer as FileHashesSerializer;
+use SmartAssert\YamlFile\YamlFile;
+use Symfony\Component\Yaml\Dumper as YamlDumper;
 
 class ApplicationTest extends TestCase
 {
@@ -16,6 +22,7 @@ class ApplicationTest extends TestCase
 
     private static Client $httpClient;
     private static string $fixturePath;
+    private static YamlFileCollectionSerializer $yamlFileCollectionSerializer;
 
     public static function setUpBeforeClass(): void
     {
@@ -25,6 +32,12 @@ class ApplicationTest extends TestCase
             'verify' => false,
         ]);
         self::$fixturePath = (string) realpath(getcwd() . '/../fixtures');
+
+        self::$yamlFileCollectionSerializer = new YamlFileCollectionSerializer(
+            new FileHashesSerializer(
+                new YamlDumper()
+            )
+        );
     }
 
     public function testCreateJob(): void
@@ -34,6 +47,7 @@ class ApplicationTest extends TestCase
                 'label' => self::JOB_LABEL,
                 'event_delivery_url' => self::EVENT_DELIVERY_URL,
                 'maximum_duration_in_seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
+                'source' => $this->createJobSource(['test.yml'], ['test.yml'])
             ],
         ]);
         self::assertSame(200, $createJobResponse->getStatusCode());
@@ -151,5 +165,42 @@ class ApplicationTest extends TestCase
         self::assertContains($job['execution_state'], $expectedJobData['execution_states']);
         self::assertContains($job['callback_state'], $expectedJobData['callback_states']);
         self::assertSame($job['tests'], $expectedJobData['tests']);
+    }
+
+    /**
+     * @param string[] $manifestPaths
+     * @param string[] $sourcePaths
+     */
+    private function createJobSource(array $manifestPaths, array $sourcePaths): string
+    {
+        $yamlFiles = [
+            YamlFile::create('manifest.yaml', $this->createManifestContent($manifestPaths))
+        ];
+
+        $fileHashes = new FileHashes();
+        foreach ($sourcePaths as $sourcePath) {
+            $content = (string) file_get_contents(self::$fixturePath . '/basil/' . $sourcePath);
+
+            $yamlFiles[] = YamlFile::create($sourcePath, $content);
+            $fileHashes->add($sourcePath, md5($content));
+        }
+
+        $yamlFileCollection = new ArrayCollection($yamlFiles);
+
+        return self::$yamlFileCollectionSerializer->serialize($yamlFileCollection);
+    }
+
+    /**
+     * @param string[] $manifestPaths
+     */
+    private function createManifestContent(array $manifestPaths): string
+    {
+        $lines = [];
+
+        foreach ($manifestPaths as $path) {
+            $lines[] = '- ' . $path;
+        }
+
+        return implode("\n", $lines);
     }
 }

--- a/self-test/app/src/ApplicationTest.php
+++ b/self-test/app/src/ApplicationTest.php
@@ -40,7 +40,7 @@ class ApplicationTest extends TestCase
         self::assertSame('application/json', $createJobResponse->getHeaderLine('content-type'));
         $this->assertJobStatus([
             'label' => self::JOB_LABEL,
-            'callback_url' => self::EVENT_DELIVERY_URL,
+            'event_delivery_url' => self::EVENT_DELIVERY_URL,
             'maximum_duration_in_seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
             'sources' => [],
             'compilation_states' => ['awaiting'],
@@ -72,7 +72,7 @@ class ApplicationTest extends TestCase
         self::assertSame('application/json', $addSourcesResponse->getHeaderLine('content-type'));
         $this->assertJobStatus([
             'label' => self::JOB_LABEL,
-            'callback_url' => self::EVENT_DELIVERY_URL,
+            'event_delivery_url' => self::EVENT_DELIVERY_URL,
             'maximum_duration_in_seconds' => self::JOB_MAXIMUM_DURATION_IN_SECONDS,
             'sources' => [
                 'test.yml',
@@ -144,7 +144,7 @@ class ApplicationTest extends TestCase
         $job = $this->getJobStatus();
 
         self::assertSame($expectedJobData['label'], $job['label']);
-        self::assertSame($expectedJobData['callback_url'], $job['callback_url']);
+        self::assertSame($expectedJobData['event_delivery_url'], $job['event_delivery_url']);
         self::assertSame($expectedJobData['maximum_duration_in_seconds'], $job['maximum_duration_in_seconds']);
         self::assertSame($expectedJobData['sources'], $job['sources']);
         self::assertContains($job['compilation_state'], $expectedJobData['compilation_states']);


### PR DESCRIPTION
Job creation self test has not run successfully for quite some time due to the DO api token beng invalid.

Need to:

 - change `callback-url` to `event_delivery_url` in the job creation request
 - change `maximum_duration_in_seconds` to `maximum_duration_in_seconds` in job creation request
 - create a job and add sources in a single request instead of creating a job and then adding sources